### PR TITLE
Removes `!!!` from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This boilerplate uses `ejs` for the [layout template](public/_layout.ejs).   To 
 **_layout.jade**
 
 ```
-!!! 5
+doctype
 html
   head
     meta(charset='utf-8')


### PR DESCRIPTION
Hey! Cool idea for a boilerplate. I just removed the `!!!` from the Jade example since that has been removed in favour of `doctype` now. (Harp v0.17.0 will still support it, but throw a warning, and in the future we may have to remove support for it entirely.)